### PR TITLE
Adding support for Yale Keyless Connected Ready Smart Door Lock

### DIFF
--- a/app.json
+++ b/app.json
@@ -335,7 +335,8 @@
           7
         ],
         "productId": [
-          0
+          0,
+          1
         ],
         "requireSecure": true,
         "learnmode": {


### PR DESCRIPTION
This adds support for Yale Keyless Connected Ready Smart Door Lock (YD-01-CON-NOMOD-CH) as per this product from Amazon UK

https://www.amazon.co.uk/gp/product/B07961CKWC

Thanks